### PR TITLE
Add RefreshSessionMiddleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 php:
   - 5.6
   - 7.0
-  - hhvm
 
 install:
   - travis_retry composer install --no-interaction --prefer-source

--- a/src/Client.php
+++ b/src/Client.php
@@ -3,6 +3,7 @@
 namespace Bunq;
 
 use Bunq\Exception\BunqException;
+use Bunq\Exception\SessionWasExpiredException;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ClientException;
 
@@ -67,11 +68,25 @@ final class Client implements BunqClient
     private function requestAPI($method, $url, array $options = [])
     {
         try {
-            $response = $this->httpClient->request((string)$method, $url, $options);
-
-            return json_decode($response->getBody(), true);
+            return $this->sendRequest((string)$method, (string)$url, $options);
+        } catch (SessionWasExpiredException $e) {
+            return $this->sendRequest((string)$method, (string)$url, $options);
         } catch (ClientException $e) {
             throw new BunqException($e);
         }
+    }
+
+    /**
+     * @param string $method
+     * @param string $url
+     * @param array  $options
+     *
+     * @return mixed
+     */
+    private function sendRequest($method, $url, array $options = [])
+    {
+        $response = $this->httpClient->request((string)$method, $url, $options);
+
+        return json_decode($response->getBody(), true);
     }
 }

--- a/src/Exception/SessionWasExpiredException.php
+++ b/src/Exception/SessionWasExpiredException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Bunq\Exception;
+
+final class SessionWasExpiredException extends \Exception
+{
+    public function __construct()
+    {
+        parent::__construct('Session has expired should now be refreshed', 400);
+    }
+}

--- a/src/Middleware/RefreshSessionMiddleware.php
+++ b/src/Middleware/RefreshSessionMiddleware.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Bunq\Middleware;
+
+use Bunq\Exception\SessionWasExpiredException;
+use Bunq\Service\InstallationService;
+use Bunq\Token\DefaultToken;
+use Bunq\Token\Storage\TokenStorage;
+use Bunq\Token\TokenType;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * bunq documentation:
+ * A session expires after the same amount of time you have set for auto logout in your user account. If a request is
+ * made 30 seconds before a session expires, it will automatically be extended.
+ *
+ * This middleware detects if the session has expired, if so, the middleware will renew the session and throws an
+ * exception to let the client know it can be retried.
+ */
+final class RefreshSessionMiddleware
+{
+    /**
+     * @var InstallationService
+     */
+    private $installationService;
+
+    /**
+     * @var TokenStorage
+     */
+    private $tokenStorage;
+
+    /**
+     * @param InstallationService $installationService
+     * @param TokenStorage        $tokenStorage
+     */
+    public function __construct(
+        InstallationService $installationService,
+        TokenStorage $tokenStorage
+    ) {
+        $this->installationService = $installationService;
+        $this->tokenStorage        = $tokenStorage;
+    }
+
+    /**
+     * @param ResponseInterface $response
+     *
+     * @return ResponseInterface
+     * @throws \Exception
+     */
+    public function __invoke(ResponseInterface $response)
+    {
+        if ($response->getStatusCode() !== 401) {
+            return $response;
+        }
+
+        $responseBody = \json_decode($response->getBody()->__toString(), true);
+
+        if ($responseBody['Error'][0]['error_description'] !== 'Insufficient authorisation.') {
+            return $response;
+        }
+
+        // make new session
+
+        $installationToken = $currentInstalltionToken = $this->tokenStorage->load(TokenType::INSTALLATION_TOKEN());
+        $session           = $this->installationService->createSession($installationToken);
+
+        $sessionToken = DefaultToken::fromString($session);
+
+        $this->tokenStorage->save($sessionToken, TokenType::SESSION_TOKEN());
+
+        throw new SessionWasExpiredException();
+    }
+
+}

--- a/tests/Exception/BunqExceptionTest.php
+++ b/tests/Exception/BunqExceptionTest.php
@@ -38,6 +38,5 @@ final class BunqExceptionTest extends TestCase
         $this->assertInstanceOf(\Exception::class, $bunqException);
         $this->assertSame('Path: /path, Message: body', $bunqException->getMessage());
         $this->assertSame(403, $bunqException->getCode());
-
     }
 }

--- a/tests/Exception/SessionExpiredExceptionTest.php
+++ b/tests/Exception/SessionExpiredExceptionTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Bunq\Tests\Exception;
+
+use Bunq\Exception\SessionWasExpiredException;
+use PHPUnit\Framework\TestCase;
+
+final class SessionWasExpiredExceptionTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function itRepresentsASessionWasExpiredException()
+    {
+        $sessionWasExpiredException = new SessionWasExpiredException();
+
+        $this->assertInstanceOf(SessionWasExpiredException::class, $sessionWasExpiredException);
+        $this->assertInstanceOf(\Exception::class, $sessionWasExpiredException);
+        $this->assertSame('Session has expired should now be refreshed', $sessionWasExpiredException->getMessage());
+        $this->assertSame(400, $sessionWasExpiredException->getCode());
+    }
+}
+

--- a/tests/Middleware/RefreshSessionMiddlewareTest.php
+++ b/tests/Middleware/RefreshSessionMiddlewareTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Bunq\Tests\Middleware;
+
+use Bunq\Middleware\RefreshSessionMiddleware;
+use Bunq\Service\InstallationService;
+use Bunq\Token\DefaultToken;
+use Bunq\Token\Storage\TokenStorage;
+use Bunq\Token\TokenType;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Http\Message\ResponseInterface;
+
+final class RefreshSessionMiddlewareTest extends TestCase
+{
+    /**
+     * @var InstallationService|ObjectProphecy
+     */
+    private $installationService;
+
+    /**
+     * @var TokenStorage|ObjectProphecy
+     */
+    private $tokenStorage;
+
+    /**
+     * @var RefreshSessionMiddleware
+     */
+    private $middleware;
+
+    public function setUp()
+    {
+        $this->installationService = $this->prophesize(InstallationService::class);
+        $this->tokenStorage        = $this->prophesize(TokenStorage::class);
+
+        $this->middleware = new RefreshSessionMiddleware(
+            $this->installationService->reveal(),
+            $this->tokenStorage->reveal()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itWontGetExecutedWhenResponseIsNot401()
+    {
+        $response = new Response(200, [], '{"ok"}');
+
+        $this->tokenStorage->load(Argument::any())->shouldNotBeCalled();
+
+        $resultResponse = $this->middleware->__invoke($response);
+
+        $this->assertSame($response, $resultResponse);
+    }
+
+    /**
+     * @test
+     */
+    public function itWontGetExecutedWhenResponseIsNotInsufficientAuthorisation()
+    {
+        $body = '{"Error":[{"error_description": "An other error"}]}';
+        $response = new Response(401, [], $body);
+
+        $this->tokenStorage->load(Argument::any())->shouldNotBeCalled();
+
+        $resultResponse = $this->middleware->__invoke($response);
+
+        $this->assertEquals($response, $resultResponse);
+    }
+
+    /**
+     * @test
+     * @expectedException \Bunq\Exception\SessionWasExpiredException
+     */
+    public function itWillRefreshSessionAndThrowsAnExceptionIfInsufficientAuthorisation()
+    {
+        $body = '{"Error":[{"error_description": "Insufficient authorisation."}]}';
+        $response = new Response(401, [], $body);
+
+        $installationToken = new DefaultToken('Installation Token');
+        $this->tokenStorage->load(TokenType::INSTALLATION_TOKEN())->willReturn($installationToken);
+        $this->installationService->createSession($installationToken)->willReturn('someSessionId');
+
+        $sessionToken = DefaultToken::fromString('someSessionId');
+
+        $this->tokenStorage->save($sessionToken, TokenType::SESSION_TOKEN())->shouldBeCalled();
+
+        $this->middleware->__invoke($response);
+    }
+}
+


### PR DESCRIPTION
Not sure if this is the best solution.. but it works :)

BC break so commits will be in v2.0.0


Explanation
=========
bunq documentation:
> A session expires after the same amount of time you have set for auto logout in your user account. If a request is made 30 seconds before a session expires, it will automatically be extended.

So basically what this middleware does is making a new session and storing it.
After storing it, an exception will be thrown so the client can catch it and retry the request.